### PR TITLE
add option for passing header with user specified secret

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
+	flagSet.String("proxy-secret-value", "", "adds a HTTP X-Proxy-Secret Header with given value")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")

--- a/options.go
+++ b/options.go
@@ -48,6 +48,7 @@ type Options struct {
 	PassAccessToken    bool     `flag:"pass-access-token" cfg:"pass_access_token"`
 	PassHostHeader     bool     `flag:"pass-host-header" cfg:"pass_host_header"`
 	SkipProviderButton bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
+	ProxySecretValue   string   `flag:"proxy-secret-value" cfg:"proxy_secret_value"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.
@@ -85,6 +86,7 @@ func NewOptions() *Options {
 		SkipProviderButton:  false,
 		ApprovalPrompt:      "force",
 		RequestLogging:      true,
+		ProxySecretValue:	   "",
 	}
 }
 


### PR DESCRIPTION
# WHAT

This adds a option an option to include an additional header `OAuth2-Proxy-Secret` with a user specified value.
# WHY

This allows the upstream application to validate traffic is coming through the proxy correctly.
# NOTE

This feature has been pushed to our docker hub repo as `kickstarter/oauth2_proxy:headers`.
# WHO

:wave: @ktheory 
